### PR TITLE
Added read time to blogs list page and blog

### DIFF
--- a/_includes/read-time.html
+++ b/_includes/read-time.html
@@ -1,0 +1,18 @@
+<span class="read-time">
+  {{ include.bracket_start }}
+
+  {% if include.approx == 'true' %}
+    ~
+  {% endif %}
+
+  {% assign words = include.content | number_of_words %}
+
+  {% if words < 360 %}
+    1 {{ include.unit }}
+  {% else %}
+    {{ words | divided_by:180 }} {{ include.unit }}s
+  {% endif %}
+
+  {{ include.caption }}
+  {{ include.bracket_end }}
+</span>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,6 +12,14 @@ layout: default
               <p class="title article-title">{{ page.title}}</p>
               <p class="subtitle is-6 article-subtitle">
                 <i class="fas fa-calendar-alt"></i> {{ page.date | date: "%-d %B, %Y" }}
+                {% include read-time.html
+                           content=content
+                           bracket_start='('
+                           bracket_end=')'
+                           unit='min'
+                           approx='true'
+                           caption='read'
+                %}
               </p>
             </div>
           </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -13,6 +13,14 @@ excerpt_separator: "more"
               <p class="title article-title"><a href="{{post.url}}">{{ post.title}}</a></p>
               <p class="subtitle is-6 article-subtitle">
                 <i class="fas fa-calendar-alt"></i> {{ post.date | date: "%-d %B, %Y"}}
+                {% include read-time.html
+                           content=post.content
+                           bracket_start='('
+                           bracket_end=')'
+                           unit='min'
+                           approx='true'
+                           caption='read'
+                %}
               </p>
             </div>
           </div>


### PR DESCRIPTION
Used the standard words count stretagy
https://carlosbecker.com/posts/jekyll-reading-time-without-plugins/

## Blogs list
![screenshot from 2018-12-21 07-18-53](https://user-images.githubusercontent.com/1132451/50320139-fe806400-04f0-11e9-961c-810429cc786a.png)

## Blog
![screenshot from 2018-12-21 07-19-01](https://user-images.githubusercontent.com/1132451/50320144-04764500-04f1-11e9-8c5d-4444badc29c2.png)

