### PR TITLE
Use proper term for MC

### DIFF
--- a/js/meetup/data.js
+++ b/js/meetup/data.js
@@ -7,6 +7,10 @@ const meetups = [
     end_time: '02:00 pm',
     address: 'Sainbu, Bhaisepati · Kathmandu',
     hosted_by: {
+      name: 'Saroj Maharjan',
+      twitter_username: 'zoraslapen'
+    },
+    master_of_ceremonies(mc): {
       name: 'Susan Joshi',
       twitter_username: 'josisusan'
     },


### PR DESCRIPTION
 MC noun
- short for master of ceremonies.

Master of Ceremonies noun
a person who presides over a formal event or entertainment and who introduces guests, speakers, or entertainers:
   the Master of Ceremonies will announce the cake-cutting 