### PR TITLE
Fix www blog redirect

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,4 +252,4 @@ RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.4.3
+   2.4.6

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "https://www.rubynepal.org/blog/*"
+  to = "https://rubynepal.org/blog/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
Problem: Currently blog with www subdomain redirects to root domain instead of blog without www

- [x] Redirect www blog to apex domain with redirect
- [x] Update bundler from 2.4.3 to 2.4.6 with `bundle update --bundler`